### PR TITLE
allow specifying custom modules in :flowy :prometheus

### DIFF
--- a/lib/flowy/prometheus.ex
+++ b/lib/flowy/prometheus.ex
@@ -27,6 +27,8 @@ defmodule Flowy.Prometheus do
     {Plugins.Phoenix, router: router, endpoint: endpoint}
   end
 
+  def plugin({plugin}), do: plugin
+
   def plugin(plugin) do
     plugin_name = plugin |> Atom.to_string() |> Macro.camelize()
     "Elixir.PromEx.Plugins.#{plugin_name}" |> String.to_existing_atom()


### PR DESCRIPTION
Updates `plugin` to first try expand the module name to Elxir.PromEx.Plugins.$NAME, and if String.to_existing_atom() throws an error, assume the `plugin` atom is a full module path to a custom plugin.

e.g.:

```elixir
config :flowy, :prometheus,
  opt_app: :my_app,
  module_name: MyAppWeb,
  datasource_id: System.get_env("PROM_DATASOURCE_ID"),
  plugins: [
    :application,
    :beam,
    :phoenix,
    :ecto,
    :phoenix_live_view,
    MyApp.Metrics.Health
  ],

```