### PR TITLE
fix broken test. Fix typespecs around http requests.

### DIFF
--- a/lib/flowy/support/http.ex
+++ b/lib/flowy/support/http.ex
@@ -4,7 +4,7 @@ defmodule Flowy.Support.Http do
           opts: keyword()
         }
 
-  @type response :: Flowy.Support.Http.Response.t()
+  @type response :: {:ok, Flowy.Support.Http.Response.t()} | {:error, Flowy.Support.Http.Response.t()}
 
   defstruct [:client, :opts]
 
@@ -68,7 +68,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a GET request.
   """
-  @spec get(url :: String.t(), headers :: keyword()) :: response
+  @spec get(url :: String.t(), headers :: list()) :: response
   def get(url, headers) do
     build()
     |> get(url, headers)
@@ -77,7 +77,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a GET request, using the provided client.
   """
-  @spec get(t(), url :: String.t(), headers :: keyword()) :: response
+  @spec get(t(), url :: String.t(), headers :: list()) :: response
   def get(module, url, headers) do
     do_request(
       module,
@@ -90,7 +90,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a POST request.
   """
-  @spec post(url :: String.t(), body :: map(), headers :: keyword()) :: response
+  @spec post(url :: String.t(), body :: map(), headers :: list()) :: response
   def post(url, body, headers) do
     build()
     |> post(url, body, headers)
@@ -99,7 +99,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a POST request, using the provided client.
   """
-  @spec post(client :: t(), url :: String.t(), body :: map(), headers :: keyword()) :: response
+  @spec post(client :: t(), url :: String.t(), body :: map(), headers :: list()) :: response
   def post(module, url, body, headers) do
     do_request(
       module,
@@ -113,7 +113,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a PUT request.
   """
-  @spec put(url :: String.t(), body :: map(), headers :: keyword()) :: response
+  @spec put(url :: String.t(), body :: map(), headers :: list()) :: response
   def put(url, body, headers) do
     build()
     |> put(url, body, headers)
@@ -122,7 +122,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a PUT request, using the provided client.
   """
-  @spec put(client :: t(), url :: String.t(), body :: map(), headers :: keyword()) :: response
+  @spec put(client :: t(), url :: String.t(), body :: map(), headers :: list()) :: response
   def put(module, url, body, headers) do
     do_request(
       module,
@@ -136,7 +136,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a PATCH request.
   """
-  @spec patch(url :: String.t(), body :: map(), headers :: keyword()) :: response
+  @spec patch(url :: String.t(), body :: map(), headers :: list()) :: response
   def patch(url, body, headers) do
     build()
     |> patch(url, body, headers)
@@ -145,7 +145,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a PATCH request, using the provided client.
   """
-  @spec patch(client :: t(), url :: String.t(), body :: map(), headers :: keyword()) :: response
+  @spec patch(client :: t(), url :: String.t(), body :: map(), headers :: list()) :: response
   def patch(module, url, body, headers) do
     do_request(
       module,
@@ -159,7 +159,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a DELETE request.
   """
-  @spec delete(url :: String.t(), headers :: keyword()) :: response
+  @spec delete(url :: String.t(), headers :: list()) :: response
   def delete(url, headers) do
     build()
     |> delete(url, headers)
@@ -168,7 +168,7 @@ defmodule Flowy.Support.Http do
   @doc """
   Makes a DELETE request, using the provided client.
   """
-  @spec delete(client :: t(), url :: String.t(), headers :: keyword()) :: response
+  @spec delete(client :: t(), url :: String.t(), headers :: list()) :: response
   def delete(module, url, headers) do
     do_request(
       module,
@@ -178,6 +178,7 @@ defmodule Flowy.Support.Http do
     )
   end
 
+  @spec do_request(t(), atom(), String.t(), list()) :: response
   def do_request(%__MODULE__{client: client, opts: opts}, method, url, headers) do
     meta = build_meta(method, url)
 
@@ -198,6 +199,7 @@ defmodule Flowy.Support.Http do
     result
   end
 
+  @spec do_request(t(), atom(), String.t(), list(), map()) :: response
   def do_request(%__MODULE__{client: client, opts: opts}, method, url, headers, body) do
     meta = build_meta(method, url)
 

--- a/lib/flowy/support/http.ex
+++ b/lib/flowy/support/http.ex
@@ -4,7 +4,8 @@ defmodule Flowy.Support.Http do
           opts: keyword()
         }
 
-  @type response :: {:ok, Flowy.Support.Http.Response.t()} | {:error, Flowy.Support.Http.Response.t()}
+  @type response ::
+          {:ok, Flowy.Support.Http.Response.t()} | {:error, Flowy.Support.Http.Response.t()}
 
   defstruct [:client, :opts]
 

--- a/lib/flowy/support/http/request.ex
+++ b/lib/flowy/support/http/request.ex
@@ -15,7 +15,13 @@ defmodule Flowy.Support.Http.Request do
   @doc """
   Builds a new request struct.
   """
-  @spec build(method :: atom(), url :: String.t(), headers :: list(), body :: map() | nil, opts :: keyword()) :: t()
+  @spec build(
+          method :: atom(),
+          url :: String.t(),
+          headers :: list(),
+          body :: map() | nil,
+          opts :: keyword()
+        ) :: t()
   def build(method, url, headers \\ [], body \\ nil, opts \\ []) do
     %__MODULE__{
       method: method,

--- a/lib/flowy/support/http/request.ex
+++ b/lib/flowy/support/http/request.ex
@@ -5,9 +5,9 @@ defmodule Flowy.Support.Http.Request do
   @type t :: %__MODULE__{
           method: atom(),
           url: String.t(),
-          body: map(),
-          headers: map(),
-          opts: map()
+          body: map() | nil,
+          headers: list(),
+          opts: keyword()
         }
 
   defstruct [:method, :url, :body, :headers, :opts]
@@ -15,8 +15,7 @@ defmodule Flowy.Support.Http.Request do
   @doc """
   Builds a new request struct.
   """
-  @spec build(method :: atom(), url :: String.t(), headers :: map(), body :: map(), opts :: map()) ::
-          t()
+  @spec build(method :: atom(), url :: String.t(), headers :: list(), body :: map() | nil, opts :: keyword()) :: t()
   def build(method, url, headers \\ [], body \\ nil, opts \\ []) do
     %__MODULE__{
       method: method,

--- a/test/mix/tasks/flowy.gen.json_test.exs
+++ b/test/mix/tasks/flowy.gen.json_test.exs
@@ -129,13 +129,13 @@ defmodule Mix.Tasks.Flowy.Gen.JsonTest do
       Gen.Json.run(~w(Blogs Post posts title))
 
       assert_file("lib/flowy/core/blogs.ex", fn file ->
-        assert file =~ "defdelegate get(id), to: PostQuery"
+        assert file =~ "defdelegate get(id, opts \\\\ []), to: PostQuery"
         assert file =~ "defdelegate last(limit), to: PostQuery"
-        assert file =~ "defdelegate get!(id), to: PostQuery"
+        assert file =~ "defdelegate get!(id, opts \\\\ []), to: PostQuery"
         assert file =~ "defdelegate update!(model, attrs), to: PostQuery"
         assert file =~ "defdelegate update(model, attrs), to: PostQuery"
         assert file =~ "defdelegate delete(model), to: PostQuery"
-        assert file =~ "defdelegate create(attrs), to: PostQuery"
+        assert file =~ "defdelegate create(attrs, opts \\\\ []), to: PostQuery"
         assert file =~ "defdelegate change(model, attrs \\\\ %{}), to: PostQuery, as: :changeset"
       end)
 
@@ -145,14 +145,14 @@ defmodule Mix.Tasks.Flowy.Gen.JsonTest do
                        ["You are generating into an existing context" <> _notice]}
 
       assert_file("lib/flowy/core/blog.ex", fn file ->
-        assert file =~ "defdelegate all, to: CommentQuery"
-        assert file =~ "defdelegate get(id), to: CommentQuery"
+        assert file =~ "defdelegate all(opts \\\\ []), to: CommentQuery"
+        assert file =~ "defdelegate get(id, opts \\\\ []), to: CommentQuery"
         assert file =~ "defdelegate last(limit), to: CommentQuery"
-        assert file =~ "defdelegate get!(id), to: CommentQuery"
+        assert file =~ "defdelegate get!(id, opts \\\\ []), to: CommentQuery"
         assert file =~ "defdelegate update!(model, attrs), to: CommentQuery"
         assert file =~ "defdelegate update(model, attrs), to: CommentQuery"
         assert file =~ "defdelegate delete(model), to: CommentQuery"
-        assert file =~ "defdelegate create(attrs), to: CommentQuery"
+        assert file =~ "defdelegate create(attrs, opts \\\\ []), to: CommentQuery"
 
         assert file =~
                  "defdelegate change(model, attrs \\\\ %{}), to: CommentQuery, as: :changeset"


### PR DESCRIPTION
The broken typespecs are really bugging me in a downstream project consuming this library. This causes any code using `Flowy.Support.Http`-based stuff to report dialyzer errors like `this function call can never succeed` and `this function never returns`, which is annoying.