### PR TITLE
http response bodies can also be lists

### DIFF
--- a/lib/flowy/support/http/response.ex
+++ b/lib/flowy/support/http/response.ex
@@ -3,7 +3,7 @@ defmodule Flowy.Support.Http.Response do
   This module defines the behaviour for HTTP responses.
   """
   @type t :: %__MODULE__{
-          body: map(),
+          body: map() | list(),
           http_code: integer(),
           headers: map(),
           error: any()


### PR DESCRIPTION
(actually i think more types than just objects or arrays can be valid JSON but these are the two main types)